### PR TITLE
fix: properly escape Gemini JSON control characters

### DIFF
--- a/src/ai/providers/gemini-intent.provider.ts
+++ b/src/ai/providers/gemini-intent.provider.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { IIntentInterpreter, InterpretedIntent } from '../interfaces/intent-interpreter.interface';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { getIntentSystemPrompt } from '../prompts/intent-prompts';
+import { sanitizeGeminiJson } from '../utils/sanitize-gemini-json.util';
 
 @Injectable()
 export class GeminiIntentProvider implements IIntentInterpreter {
@@ -26,12 +27,9 @@ export class GeminiIntentProvider implements IIntentInterpreter {
 
     const result = await this.model.generateContent(systemPrompt);
     const response = await result.response;
-    const text = response
-      .text()
-      .replace(/```json/g, '')
-      .replace(/```/g, '')
-      .trim()
-      .replace(/[\u0000-\u001F\u007F]/g, '');
+    const text = sanitizeGeminiJson(
+      response.text().replace(/```json/g, '').replace(/```/g, '').trim(),
+    );
 
     try {
       return JSON.parse(text);

--- a/src/ai/providers/gemini-script.provider.ts
+++ b/src/ai/providers/gemini-script.provider.ts
@@ -6,6 +6,7 @@ import {
 } from '../interfaces/script-generator.interface';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import { getScriptGenerationPrompt, getSimpleScriptPrompt } from '../prompts/script-prompts';
+import { sanitizeGeminiJson } from '../utils/sanitize-gemini-json.util';
 
 @Injectable()
 export class GeminiScriptProvider implements IScriptGenerator {
@@ -82,10 +83,7 @@ export class GeminiScriptProvider implements IScriptGenerator {
       .replace(/```/g, '')
       .trim();
 
-    // Strip literal control characters. Gemini occasionally emits raw control chars
-    // (e.g. \n inside string values) which are invalid JSON. JSON is whitespace-insensitive
-    // so removing formatting newlines is safe; control chars in strings are just stripped.
-    const text = raw.replace(/[\u0000-\u001F\u007F]/g, '');
+    const text = sanitizeGeminiJson(raw);
 
     try {
       return JSON.parse(text);

--- a/src/ai/utils/sanitize-gemini-json.util.ts
+++ b/src/ai/utils/sanitize-gemini-json.util.ts
@@ -1,0 +1,63 @@
+/**
+ * Sanitize a raw string from Gemini before JSON.parse.
+ *
+ * Gemini occasionally emits literal control characters (bytes 0x00–0x1F, 0x7F)
+ * inside JSON string values, which is invalid per the JSON spec.  A naïve
+ * global strip loses content (e.g. newlines in scene descriptions).
+ *
+ * This function walks the raw string character-by-character and:
+ *  - Inside a JSON string value  → escapes the control char (\\n, \\t, etc.)
+ *    so the content is preserved and the JSON becomes valid.
+ *  - Outside a JSON string value → strips the control char (it was only
+ *    formatting whitespace; JSON is whitespace-insensitive).
+ */
+export function sanitizeGeminiJson(raw: string): string {
+  const ESCAPE_MAP: Record<string, string> = {
+    '\b': '\\b',
+    '\t': '\\t',
+    '\n': '\\n',
+    '\f': '\\f',
+    '\r': '\\r',
+  };
+
+  let result = '';
+  let inString = false;
+  let i = 0;
+
+  while (i < raw.length) {
+    const char = raw[i];
+    const code = raw.charCodeAt(i);
+
+    // Handle backslash escape sequences inside strings — skip next char as-is.
+    if (inString && char === '\\') {
+      result += char + (raw[i + 1] ?? '');
+      i += 2;
+      continue;
+    }
+
+    // Toggle string context on unescaped double-quote.
+    if (char === '"') {
+      inString = !inString;
+      result += char;
+      i++;
+      continue;
+    }
+
+    // Control character (C0 range + DEL).
+    if (code <= 0x1f || code === 0x7f) {
+      if (inString) {
+        // Preserve content by escaping; fall back to empty string for rare
+        // non-printable control chars (SOH, STX, …) that have no JSON escape.
+        result += ESCAPE_MAP[char] ?? '';
+      }
+      // Outside a string: just drop it (was only structural whitespace).
+      i++;
+      continue;
+    }
+
+    result += char;
+    i++;
+  }
+
+  return result;
+}


### PR DESCRIPTION
Fixes #2

Gemini occasionally emits literal control characters inside JSON string values, causing "Bad control character in string literal" parse errors. Replaces the blunt global strip with a character-by-character sanitizer that escapes control chars within strings (preserving content) and strips them outside strings (formatting whitespace).

Generated with [Claude Code](https://claude.ai/code)